### PR TITLE
Export IMAGE accessor

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -41,6 +41,7 @@
    #:clear-canvas
    #:save-png
    #:save-png-stream
+   #:image
    ;; path construction
    #:move-to
    #:line-to


### PR DESCRIPTION
I want to be able to access the raw ARGB data of the image, so I can further process it with other graphical tools. Right now, I can only export it to PNG file, which causes unnecessary PNG write and read if I want to simply read the image data.