### PR TITLE
Add radial gradients

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -404,6 +404,20 @@ to the end color from the start point to the midpoint, then back to
 the start color from the midpoint to the end point
 </ul>
 
+
+<p>Two coordinate functions are available:
+
+<ul>
+
+<li> <tt>CARTESIAN-COORDINATES</tt>, the default, creates a linear
+gradient.
+
+<li> <tt>POLAR-COORDINATES</tt> creates a radial gradient with the
+start point denoting the start of the circle and the end point
+denoting the ending circle.
+</ul>
+
+
 <pre><img style='float: right' class='transparent'
  src='linear-gradient.png'>(defun gradient-example (file)
   (with-canvas (:width 200 :height 50)

--- a/package.lisp
+++ b/package.lisp
@@ -81,6 +81,8 @@
    #:set-gradient-fill
    #:linear-domain
    #:bilinear-domain
+   #:cartesian-coordinates
+   #:polar-coordinates
    ;; graphics state coordinate transforms
    #:translate
    #:rotate


### PR DESCRIPTION
This change makes it possible to have radial gradients in Vecto, as opposed to only linear gradients.

This is achieved via a new keyword parameter to `set-gradient-fill`, `:coordinates-function`, and two default coordinate functions, `cartesian-coordinates` (for linear gradients) and `polar-coordinates` (for radial gradients).

In the first example, we have the legacy behavior and a linear gradient; in the second example, we have a radial gradient with the same parameters.

Here is the test function:

```lisp
(defun test (coordinates)
  (let* ((height 800)
         (width (round (* height 2 (/ (sqrt 3)))))
         (side (/ width 2))
         (center-x (floor width 2))
         (center-y (floor height 2)))
    (flet ((hexagon (side)
             (let ((half-height (* side 1d0 (sqrt 3) 1/2)))
               (move-to (- side) 0)
               (line-to (- (/ side 2)) (+ half-height))
               (line-to (+ (/ side 2)) (+ half-height))
               (line-to (+ side) 0)
               (line-to (+ (/ side 2)) (- half-height))
               (line-to (- (/ side 2)) (- half-height))
               (line-to (- side) 0))))
      (with-canvas (:width width :height height)
        (translate center-x center-y)
        (with-graphics-state
          (set-rgba-fill 0.5 0.25 0 1)
          (hexagon (1- side))
          (fill-path))
        (with-graphics-state
          (set-gradient-fill 0 0 0 0 0 1
                               (* 1/2 side) 0 0 0 0 0
                               :coordinates-function coordinates)
          (hexagon (1- side))
          (fill-path))
        (save-png #p"/tmp/vecto.png")))))
```

`(test 'cartesian-coordinates)`:
![vecto](https://user-images.githubusercontent.com/15045546/147741789-08eb3e6d-4bae-48c2-a237-eb3826f343b2.png)

`(test 'polar-coordinates)`:
![vecto](https://user-images.githubusercontent.com/15045546/147741813-cfc860bb-a2d9-4bb8-a1cb-2806eae023d7.png)